### PR TITLE
GetOPT

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,10 +28,19 @@ func (c *Client) Close() error {
 }
 
 // GetOPE Connect to db to collect data to build 'Órgao por estado' screen
-func (c *Client) GetOPE(Uf string, Year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPE(Uf, Year)
+func (c *Client) GetOPE(Group string, Uf string, Year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPE(Group, Uf, Year)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
+	}
+	return ags, err
+}
+
+// GetOPT Connect to db to collect data to build 'Órgao por grupo' screen
+func (c *Client) GetOPT(Group string, Year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPT(Group, Year)
+	if err != nil {
+		return nil, fmt.Errorf("GetOPT() error: %q", err)
 	}
 	return ags, err
 }

--- a/repositories/database/mongo/mongo.go
+++ b/repositories/database/mongo/mongo.go
@@ -67,10 +67,19 @@ func (c *DBClient) Disconnect() error {
 }
 
 // GetOPE return agmi info to build first screen
-func (c *DBClient) GetOPE(uf string, year int) ([]models.Agency, error) {
+func (c *DBClient) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
 	allAgencies, err := c.GetAgencies(uf)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
+	}
+	return allAgencies, nil
+}
+
+// GetOPT Return the Agencies by group (Federal, Estadual, Militar...)
+func (c *DBClient) GetOPT(group string, year int) ([]models.Agency, error) {
+	allAgencies, err := c.GetAgenciesByType(group)
+	if err != nil {
+		return nil, fmt.Errorf("GetOPT() error: %q", err)
 	}
 	return allAgencies, nil
 }
@@ -99,6 +108,21 @@ func (c *DBClient) GetNumberOfMonthsCollected() (int64, error) {
 func (c *DBClient) GetAgencies(uf string) ([]models.Agency, error) {
 	c.Collection(c.agencyCol)
 	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"uf": uf}}}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error in getAgencies %v", err)
+	}
+	var allAgencies []models.Agency
+	resultAgencies.All(context.TODO(), &allAgencies)
+	if err := resultAgencies.Err(); err != nil {
+		return nil, fmt.Errorf("error in getAgencies %v", err)
+	}
+	return allAgencies, nil
+}
+
+//GetAgenciesByType Return TYPE Agencies
+func (c *DBClient) GetAgenciesByType(group string) ([]models.Agency, error) {
+	c.Collection(c.agencyCol)
+	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"type": group}}}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error in getAgencies %v", err)
 	}

--- a/repositories/database/postgres/postgres.go
+++ b/repositories/database/postgres/postgres.go
@@ -140,11 +140,29 @@ func (p *PostgresDB) StorePackage(newPackage models.Package) error {
 	panic("implement me")
 }
 
-func (p *PostgresDB) GetOPE(uf string, year int) ([]models.Agency, error) {
+func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
-	if err := p.db.Model(&dto.AgencyDTO{}).Where("uf = ?", uf).Find(&dtoOrgaos).Error; err != nil {
+	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ? AND uf = ?", group, uf).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies: %q", err)
 	}
+
+	var orgaos []models.Agency
+	for _, dtoOrgao := range dtoOrgaos {
+		orgao, err := dtoOrgao.ConvertToModel()
+		if err != nil {
+			return nil, fmt.Errorf("error converting agency dto to model: %q", err)
+		}
+		orgaos = append(orgaos, *orgao)
+	}
+	return orgaos, nil
+}
+
+func (p *PostgresDB) GetOPT(group string, year int) ([]models.Agency, error) {
+	var dtoOrgaos []dto.AgencyDTO
+	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ?", group).Find(&dtoOrgaos).Error; err != nil {
+		return nil, fmt.Errorf("error getting agencies by type: %q", err)
+	}
+
 	var orgaos []models.Agency
 	for _, dtoOrgao := range dtoOrgaos {
 		orgao, err := dtoOrgao.ConvertToModel()

--- a/repositories/interfaces/IDatabaseRepository.go
+++ b/repositories/interfaces/IDatabaseRepository.go
@@ -11,7 +11,9 @@ type IDatabaseRepository interface {
 	StorePackage(newPackage models.Package) error
 	StoreRemunerations(remu models.Remunerations) error
 	// OPE : Órgãos Por Estado
-	GetOPE(uf string, year int) ([]models.Agency, error)
+	GetOPE(group string, uf string, year int) ([]models.Agency, error)
+	// OPT: Órgãos por tipo.
+	GetOPT(group string, year int) ([]models.Agency, error)
 	GetAgenciesCount() (int64, error)
 	GetNumberOfMonthsCollected() (int64, error)
 	GetAgencies(uf string) ([]models.Agency, error)


### PR DESCRIPTION
A [issue 517](https://github.com/dadosjusbr/api/issues/517) pede a modificação da field uf dos órgãos militares, trabalho, etc...
No entanto, a consulta nos BDs é realizada pela UF e não pela jurisdição, então essa modificação direta faria com que esses órgãos não aparecessem em seus respectivos grupos, e, sim, juntamente a Justiça Estadual com a UF correspondente.

A modificação desse PR faz a consulta pela jurisdição e uf, ex.:
- v1/orgao/Eleitoral = todos eleitorais
- v1/orgao/Estadual = todos estaduais
- v1/orgao/Estadual/AL = tjal e mpal

Vale lembrar que a api e o front precisarão ser modificados tbm.
A modificação da api  já foi feita, mas preciso  atualizar a versão do storage para enviar o PR