### PR TITLE
GetOPT

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,19 +28,19 @@ func (c *Client) Close() error {
 }
 
 // GetOPE Connect to db to collect data to build 'Órgao por estado' screen
-func (c *Client) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPE(group, uf, year)
+func (c *Client) GetOPE(uf string, year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPE(uf, year)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
 	}
 	return ags, err
 }
 
-// GetOPT Connect to db to collect data to build 'Órgao por grupo' screen
-func (c *Client) GetOPT(group string, year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPT(group, year)
+// GetOPJ Connect to db to collect data to build 'Órgao por jurisdição' screen
+func (c *Client) GetOPJ(group string, year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPJ(group, year)
 	if err != nil {
-		return nil, fmt.Errorf("GetOPT() error: %q", err)
+		return nil, fmt.Errorf("GetOPJ() error: %q", err)
 	}
 	return ags, err
 }

--- a/client.go
+++ b/client.go
@@ -28,10 +28,19 @@ func (c *Client) Close() error {
 }
 
 // GetOPE Connect to db to collect data to build 'Órgao por estado' screen
-func (c *Client) GetOPE(Uf string, Year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPE(Uf, Year)
+func (c *Client) GetOPE(Group string, Uf string, Year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPE(Group, Uf, Year)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
+	}
+	return ags, err
+}
+
+// GetOPT Connect to db to collect data to build 'Órgao por grupo' screen
+func (c *Client) GetOPT(Group string, Year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPT(Group, Year)
+	if err != nil {
+		return nil, fmt.Errorf("GetOPT() error: %q", err)
 	}
 	return ags, err
 }

--- a/client.go
+++ b/client.go
@@ -28,8 +28,8 @@ func (c *Client) Close() error {
 }
 
 // GetOPE Connect to db to collect data to build 'Órgao por estado' screen
-func (c *Client) GetOPE(Group string, Uf string, Year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPE(Group, Uf, Year)
+func (c *Client) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPE(group, uf, year)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
 	}
@@ -37,8 +37,8 @@ func (c *Client) GetOPE(Group string, Uf string, Year int) ([]models.Agency, err
 }
 
 // GetOPT Connect to db to collect data to build 'Órgao por grupo' screen
-func (c *Client) GetOPT(Group string, Year int) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPT(Group, Year)
+func (c *Client) GetOPT(group string, year int) ([]models.Agency, error) {
+	ags, err := c.Db.GetOPT(group, year)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPT() error: %q", err)
 	}

--- a/repositories/database/mongo/mongo.go
+++ b/repositories/database/mongo/mongo.go
@@ -67,10 +67,19 @@ func (c *DBClient) Disconnect() error {
 }
 
 // GetOPE return agmi info to build first screen
-func (c *DBClient) GetOPE(uf string, year int) ([]models.Agency, error) {
+func (c *DBClient) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
 	allAgencies, err := c.GetAgencies(uf)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
+	}
+	return allAgencies, nil
+}
+
+// GetOPT Return the Agencies by group (Federal, Estadual, Militar...)
+func (c *DBClient) GetOPT(group string, year int) ([]models.Agency, error) {
+	allAgencies, err := c.GetAgenciesByType(group)
+	if err != nil {
+		return nil, fmt.Errorf("GetOPT() error: %q", err)
 	}
 	return allAgencies, nil
 }
@@ -99,6 +108,21 @@ func (c *DBClient) GetNumberOfMonthsCollected() (int64, error) {
 func (c *DBClient) GetAgencies(uf string) ([]models.Agency, error) {
 	c.Collection(c.agencyCol)
 	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"uf": uf}}}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error in getAgencies %v", err)
+	}
+	var allAgencies []models.Agency
+	resultAgencies.All(context.TODO(), &allAgencies)
+	if err := resultAgencies.Err(); err != nil {
+		return nil, fmt.Errorf("error in getAgencies %v", err)
+	}
+	return allAgencies, nil
+}
+
+//GetAgenciesByType Return TYPE Agencies
+func (c *DBClient) GetAgenciesByType(group string) ([]models.Agency, error) {
+	c.Collection(c.agencyCol)
+	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"type": group}}}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error in getAgencies %v", err)
 	}

--- a/repositories/database/mongo/mongo.go
+++ b/repositories/database/mongo/mongo.go
@@ -67,7 +67,7 @@ func (c *DBClient) Disconnect() error {
 }
 
 // GetOPE return agmi info to build first screen
-func (c *DBClient) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
+func (c *DBClient) GetOPE(uf string, year int) ([]models.Agency, error) {
 	allAgencies, err := c.GetAgencies(uf)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)

--- a/repositories/database/mongo/mongo.go
+++ b/repositories/database/mongo/mongo.go
@@ -75,15 +75,6 @@ func (c *DBClient) GetOPE(group string, uf string, year int) ([]models.Agency, e
 	return allAgencies, nil
 }
 
-// GetOPT Return the Agencies by group (Federal, Estadual, Militar...)
-func (c *DBClient) GetOPT(group string, year int) ([]models.Agency, error) {
-	allAgencies, err := c.GetAgenciesByType(group)
-	if err != nil {
-		return nil, fmt.Errorf("GetOPT() error: %q", err)
-	}
-	return allAgencies, nil
-}
-
 // GetAgenciesCount Return the Agencies amount
 func (c *DBClient) GetAgenciesCount() (int64, error) {
 	c.Collection(c.agencyCol)
@@ -108,21 +99,6 @@ func (c *DBClient) GetNumberOfMonthsCollected() (int64, error) {
 func (c *DBClient) GetAgencies(uf string) ([]models.Agency, error) {
 	c.Collection(c.agencyCol)
 	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"uf": uf}}}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error in getAgencies %v", err)
-	}
-	var allAgencies []models.Agency
-	resultAgencies.All(context.TODO(), &allAgencies)
-	if err := resultAgencies.Err(); err != nil {
-		return nil, fmt.Errorf("error in getAgencies %v", err)
-	}
-	return allAgencies, nil
-}
-
-//GetAgenciesByType Return TYPE Agencies
-func (c *DBClient) GetAgenciesByType(group string) ([]models.Agency, error) {
-	c.Collection(c.agencyCol)
-	resultAgencies, err := c.col.Find(context.TODO(), bson.M{"$and": []bson.M{{"type": group}}}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error in getAgencies %v", err)
 	}

--- a/repositories/database/postgres/postgres.go
+++ b/repositories/database/postgres/postgres.go
@@ -140,9 +140,9 @@ func (p *PostgresDB) StorePackage(newPackage models.Package) error {
 	panic("implement me")
 }
 
-func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
+func (p *PostgresDB) GetOPE(uf string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
-	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ? AND uf = ?", group, uf).Find(&dtoOrgaos).Error; err != nil {
+	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = 'Estadual' AND uf = ?", uf).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies: %q", err)
 	}
 
@@ -157,7 +157,7 @@ func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency,
 	return orgaos, nil
 }
 
-func (p *PostgresDB) GetOPT(group string, year int) ([]models.Agency, error) {
+func (p *PostgresDB) GetOPJ(group string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
 	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ?", group).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies by type: %q", err)

--- a/repositories/database/postgres/postgres.go
+++ b/repositories/database/postgres/postgres.go
@@ -140,11 +140,29 @@ func (p *PostgresDB) StorePackage(newPackage models.Package) error {
 	panic("implement me")
 }
 
-func (p *PostgresDB) GetOPE(uf string, year int) ([]models.Agency, error) {
+func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
-	if err := p.db.Model(&dto.AgencyDTO{}).Where("uf = ?", uf).Find(&dtoOrgaos).Error; err != nil {
+	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ? AND uf = ?", group, uf).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies: %q", err)
 	}
+
+	var orgaos []models.Agency
+	for _, dtoOrgao := range dtoOrgaos {
+		orgao, err := dtoOrgao.ConvertToModel()
+		if err != nil {
+			return nil, fmt.Errorf("error converting agency dto to model: %q", err)
+		}
+		orgaos = append(orgaos, *orgao)
+	}
+	return orgaos, nil
+}
+
+func (p *PostgresDB) GetOPT(group string, year int) ([]models.Agency, error) {
+	var dtoOrgaos []dto.AgencyDTO
+	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ?", group).Find(&dtoOrgaos).Error; err != nil {
+		return nil, fmt.Errorf("error getting agencies by type: %q", err)
+	}
+
 	var orgaos []models.Agency
 	for _, dtoOrgao := range dtoOrgaos {
 		orgao, err := dtoOrgao.ConvertToModel()

--- a/repositories/database/postgres/postgres.go
+++ b/repositories/database/postgres/postgres.go
@@ -159,6 +159,14 @@ func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency,
 
 func (p *PostgresDB) GetOPT(group string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
+	// Esse trecho [164-169] é para garantir que o site não vai quebrar antes do front ser modificado.
+	// Posteriormente isso será apagado pq não será mais necessário.
+	values := [27]string{"AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO"}
+	for k := range values {
+		if group == values[k] {
+			return p.GetOPE("Estadual", group, year)
+		}
+	}
 	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ?", group).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies by type: %q", err)
 	}

--- a/repositories/database/postgres/postgres.go
+++ b/repositories/database/postgres/postgres.go
@@ -159,14 +159,6 @@ func (p *PostgresDB) GetOPE(group string, uf string, year int) ([]models.Agency,
 
 func (p *PostgresDB) GetOPT(group string, year int) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
-	// Esse trecho [164-169] é para garantir que o site não vai quebrar antes do front ser modificado.
-	// Posteriormente isso será apagado pq não será mais necessário.
-	values := [27]string{"AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO"}
-	for k := range values {
-		if group == values[k] {
-			return p.GetOPE("Estadual", group, year)
-		}
-	}
 	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = ?", group).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies by type: %q", err)
 	}

--- a/repositories/interfaces/IDatabaseRepository.go
+++ b/repositories/interfaces/IDatabaseRepository.go
@@ -11,9 +11,9 @@ type IDatabaseRepository interface {
 	StorePackage(newPackage models.Package) error
 	StoreRemunerations(remu models.Remunerations) error
 	// OPE : Órgãos Por Estado
-	GetOPE(group string, uf string, year int) ([]models.Agency, error)
+	GetOPE(uf string, year int) ([]models.Agency, error)
 	// OPT: Órgãos por tipo.
-	GetOPT(group string, year int) ([]models.Agency, error)
+	GetOPJ(group string, year int) ([]models.Agency, error)
 	GetAgenciesCount() (int64, error)
 	GetNumberOfMonthsCollected() (int64, error)
 	GetAgencies(uf string) ([]models.Agency, error)

--- a/repositories/interfaces/IDatabaseRepository.go
+++ b/repositories/interfaces/IDatabaseRepository.go
@@ -11,7 +11,9 @@ type IDatabaseRepository interface {
 	StorePackage(newPackage models.Package) error
 	StoreRemunerations(remu models.Remunerations) error
 	// OPE : Órgãos Por Estado
-	GetOPE(uf string, year int) ([]models.Agency, error)
+	GetOPE(group string, uf string, year int) ([]models.Agency, error)
+	// OPT: Órgãos por tipo.
+	GetOPT(group string, year int) ([]models.Agency, error)
 	GetAgenciesCount() (int64, error)
 	GetNumberOfMonthsCollected() (int64, error)
 	GetAgencies(uf string) ([]models.Agency, error)

--- a/repositories/interfaces/IDatabaseRepository.go
+++ b/repositories/interfaces/IDatabaseRepository.go
@@ -12,7 +12,7 @@ type IDatabaseRepository interface {
 	StoreRemunerations(remu models.Remunerations) error
 	// OPE : Órgãos Por Estado
 	GetOPE(uf string, year int) ([]models.Agency, error)
-	// OPT: Órgãos por tipo.
+	// OPJ: Órgãos por jurisdição.
 	GetOPJ(group string, year int) ([]models.Agency, error)
 	GetAgenciesCount() (int64, error)
 	GetNumberOfMonthsCollected() (int64, error)


### PR DESCRIPTION
A [issue 517](https://github.com/dadosjusbr/api/issues/517) pede a modificação da field uf dos órgãos militares, trabalho, etc...
No entanto, a consulta nos BDs é realizada pela UF e não pela jurisdição, então essa modificação direta faria com que esses órgãos não aparecessem em seus respectivos grupos, e, sim, juntamente a Justiça Estadual com a UF correspondente.

A modificação desse PR faz a consulta pela jurisdição e uf, ex.:

v1/orgao/Eleitoral = todos eleitorais
v1/orgao/Estadual = todos estaduais
v1/orgao/Estadual/AL = tjal e mpal

Vale lembrar que a api e o front precisarão ser modificados tbm.
A modificação da api já foi feita, mas preciso atualizar a versão do storage para enviar o PR.