### PR TITLE
Test get agencies by uf

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,9 +28,9 @@ func (c *Client) Close() error {
 	return c.Db.Disconnect()
 }
 
-// GetOPE Connect to db to collect data to build 'Órgao por estado' screen
-func (c *Client) GetOPE(uf string) ([]models.Agency, error) {
-	ags, err := c.Db.GetOPE(uf)
+// GetStateAgencies Connect to db to collect state agencies by UF
+func (c *Client) GetStateAgencies(uf string) ([]models.Agency, error) {
+	ags, err := c.Db.GetStateAgencies(uf)
 	if err != nil {
 		return nil, fmt.Errorf("GetOPE() error: %q", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -44,12 +44,12 @@ func (getOPE) testWhenRepositoryReturnAgencies(t *testing.T) {
 	agencies := []models.Agency{tjsp, mpsp}
 	uf := "SP"
 
-	dbMock.EXPECT().GetOPE(uf).Return(agencies, nil)
+	dbMock.EXPECT().GetStateAgencies(uf).Return(agencies, nil)
 	dbMock.EXPECT().Connect().Return(nil)
 
 	client, err := storage.NewClient(dbMock, fsMock)
 
-	returnedAgencies, err := client.GetOPE(uf)
+	returnedAgencies, err := client.GetStateAgencies(uf)
 
 	assert.Nil(t, err)
 	assert.Equal(t, agencies, returnedAgencies)
@@ -61,11 +61,11 @@ func (getOPE) testWhenRepositoryReturnError(t *testing.T) {
 	fsMock := file_storage.NewMockInterface(mockCrl)
 
 	repoErr := errors.New("error getting agencies")
-	dbMock.EXPECT().GetOPE("SP").Return(nil, repoErr)
+	dbMock.EXPECT().GetStateAgencies("SP").Return(nil, repoErr)
 	dbMock.EXPECT().Connect().Return(nil)
 
 	client, err := storage.NewClient(dbMock, fsMock)
-	returnedAgencies, err := client.GetOPE("SP")
+	returnedAgencies, err := client.GetStateAgencies("SP")
 	expectedErr := errors.New(fmt.Sprintf("GetOPE() error: \"%s\"", repoErr.Error()))
 
 	assert.Equal(t, expectedErr, err)
@@ -78,11 +78,11 @@ func (getOPE) testWhenRepositoryReturnEmptyArray(t *testing.T) {
 	fsMock := file_storage.NewMockInterface(mockCrl)
 
 	agencies := []models.Agency{}
-	dbMock.EXPECT().GetOPE("SP").Return(agencies, nil)
+	dbMock.EXPECT().GetStateAgencies("SP").Return(agencies, nil)
 	dbMock.EXPECT().Connect().Return(nil)
 
 	client, err := storage.NewClient(dbMock, fsMock)
-	returnedAgencies, err := client.GetOPE("SP")
+	returnedAgencies, err := client.GetStateAgencies("SP")
 
 	assert.Nil(t, err)
 	assert.Equal(t, agencies, returnedAgencies)

--- a/repo/database/database_mock.go
+++ b/repo/database/database_mock.go
@@ -62,19 +62,19 @@ func (mr *MockInterfaceMockRecorder) Disconnect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockInterface)(nil).Disconnect))
 }
 
-// GetAgencies mocks base method.
-func (m *MockInterface) GetAgencies(uf string) ([]models.Agency, error) {
+// GetAgenciesByUF mocks base method.
+func (m *MockInterface) GetAgenciesByUF(uf string) ([]models.Agency, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAgencies", uf)
+	ret := m.ctrl.Call(m, "GetAgenciesByUF", uf)
 	ret0, _ := ret[0].([]models.Agency)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAgencies indicates an expected call of GetAgencies.
-func (mr *MockInterfaceMockRecorder) GetAgencies(uf interface{}) *gomock.Call {
+// GetAgenciesByUF indicates an expected call of GetAgenciesByUF.
+func (mr *MockInterfaceMockRecorder) GetAgenciesByUF(uf interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgencies", reflect.TypeOf((*MockInterface)(nil).GetAgencies), uf)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgenciesByUF", reflect.TypeOf((*MockInterface)(nil).GetAgenciesByUF), uf)
 }
 
 // GetAgenciesCount mocks base method.
@@ -245,21 +245,6 @@ func (mr *MockInterfaceMockRecorder) GetOMA(month, year, agency interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOMA", reflect.TypeOf((*MockInterface)(nil).GetOMA), month, year, agency)
 }
 
-// GetOPE mocks base method.
-func (m *MockInterface) GetOPE(uf string) ([]models.Agency, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOPE", uf)
-	ret0, _ := ret[0].([]models.Agency)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOPE indicates an expected call of GetOPE.
-func (mr *MockInterfaceMockRecorder) GetOPE(uf interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOPE", reflect.TypeOf((*MockInterface)(nil).GetOPE), uf)
-}
-
 // GetOPJ mocks base method.
 func (m *MockInterface) GetOPJ(group string) ([]models.Agency, error) {
 	m.ctrl.T.Helper()
@@ -303,6 +288,21 @@ func (m *MockInterface) GetRemunerationSummary() (*models.RemmunerationSummary, 
 func (mr *MockInterfaceMockRecorder) GetRemunerationSummary() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemunerationSummary", reflect.TypeOf((*MockInterface)(nil).GetRemunerationSummary))
+}
+
+// GetStateAgencies mocks base method.
+func (m *MockInterface) GetStateAgencies(uf string) ([]models.Agency, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStateAgencies", uf)
+	ret0, _ := ret[0].([]models.Agency)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStateAgencies indicates an expected call of GetStateAgencies.
+func (mr *MockInterfaceMockRecorder) GetStateAgencies(uf interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateAgencies", reflect.TypeOf((*MockInterface)(nil).GetStateAgencies), uf)
 }
 
 // Store mocks base method.

--- a/repo/database/interface.go
+++ b/repo/database/interface.go
@@ -11,12 +11,12 @@ type Interface interface {
 	StorePackage(newPackage models.Package) error
 	StoreRemunerations(remu models.Remunerations) error
 	// OPE : Órgãos Por Estado
-	GetOPE(uf string) ([]models.Agency, error)
+	GetStateAgencies(uf string) ([]models.Agency, error)
 	// OPJ: Órgãos por jurisdição.
 	GetOPJ(group string) ([]models.Agency, error)
 	GetAgenciesCount() (int64, error)
 	GetNumberOfMonthsCollected() (int64, error)
-	GetAgencies(uf string) ([]models.Agency, error)
+	GetAgenciesByUF(uf string) ([]models.Agency, error)
 	GetAgency(aid string) (*models.Agency, error)
 	GetAllAgencies() ([]models.Agency, error)
 	GetMonthlyInfo(agencies []models.Agency, year int) (map[string][]models.AgencyMonthlyInfo, error)

--- a/repo/database/postgres.go
+++ b/repo/database/postgres.go
@@ -144,7 +144,7 @@ func (p *PostgresDB) StorePackage(newPackage models.Package) error {
 	panic("implement me")
 }
 
-func (p *PostgresDB) GetOPE(uf string) ([]models.Agency, error) {
+func (p *PostgresDB) GetStateAgencies(uf string) ([]models.Agency, error) {
 	uf = strings.ToUpper(uf)
 	var dtoOrgaos []dto.AgencyDTO
 	if err := p.db.Model(&dto.AgencyDTO{}).Where("jurisdicao = 'Estadual' AND uf = ?", uf).Find(&dtoOrgaos).Error; err != nil {
@@ -207,8 +207,9 @@ func (p *PostgresDB) GetNumberOfMonthsCollected() (int64, error) {
 	return count, nil
 }
 
-func (p *PostgresDB) GetAgencies(uf string) ([]models.Agency, error) {
+func (p *PostgresDB) GetAgenciesByUF(uf string) ([]models.Agency, error) {
 	var dtoOrgaos []dto.AgencyDTO
+	uf = strings.ToUpper(uf)
 	if err := p.db.Model(&dto.AgencyDTO{}).Where("uf = ?", uf).Find(&dtoOrgaos).Error; err != nil {
 		return nil, fmt.Errorf("error getting agencies: %q", err)
 	}

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -29,16 +29,16 @@ func TestMain(m *testing.M) {
 	os.Exit(exitValue)
 }
 
-func TestGetOPE(t *testing.T) {
-	tests := getOPE{}
-	t.Run("Test GetOPE when agencies exists", tests.testWhenAgenciesExists)
-	t.Run("Test GetOPE when UF not exists", tests.testWhenUFNotExists)
-	t.Run("Test GetOPE when UF is in lower case", tests.testWhenUFIsInLowerCase)
+func TestGetStateAgencies(t *testing.T) {
+	tests := getStateAgencies{}
+	t.Run("Test TestGetStateAgencies when agencies exists", tests.testWhenAgenciesExists)
+	t.Run("Test TestGetStateAgencies when UF not exists", tests.testWhenUFNotExists)
+	t.Run("Test TestGetStateAgencies when UF is in lower case", tests.testWhenUFIsInLowerCase)
 }
 
-type getOPE struct{}
+type getStateAgencies struct{}
 
-func (g getOPE) testWhenAgenciesExists(t *testing.T) {
+func (g getStateAgencies) testWhenAgenciesExists(t *testing.T) {
 	agencies := []models.Agency{
 		{
 			ID:   "tjsp",
@@ -49,23 +49,23 @@ func (g getOPE) testWhenAgenciesExists(t *testing.T) {
 	if err := insertAgencies(agencies); err != nil {
 		t.Fatalf("error inserting agencies: %q", err)
 	}
-	returnedAgencies, err := postgresDb.GetOPE("SP")
+	returnedAgencies, err := postgresDb.GetStateAgencies("SP")
 
 	assert.Nil(t, err)
 	assert.Equal(t, agencies, returnedAgencies)
 	truncateTables()
 }
 
-func (g getOPE) testWhenUFNotExists(t *testing.T) {
+func (g getStateAgencies) testWhenUFNotExists(t *testing.T) {
 	truncateTables()
 
-	returnedAgencies, err := postgresDb.GetOPE("SP")
+	returnedAgencies, err := postgresDb.GetStateAgencies("SP")
 
 	assert.Nil(t, err)
 	assert.Empty(t, returnedAgencies)
 }
 
-func (g getOPE) testWhenUFIsInLowerCase(t *testing.T) {
+func (g getStateAgencies) testWhenUFIsInLowerCase(t *testing.T) {
 	agencies := []models.Agency{
 		{
 			ID:   "tjsp",
@@ -77,7 +77,7 @@ func (g getOPE) testWhenUFIsInLowerCase(t *testing.T) {
 		t.Fatalf("error inserting agencies: %q", err)
 	}
 
-	returnedAgencies, err := postgresDb.GetOPE("sp")
+	returnedAgencies, err := postgresDb.GetStateAgencies("sp")
 
 	assert.Nil(t, err)
 	assert.Equal(t, agencies, returnedAgencies)
@@ -160,6 +160,92 @@ func (g getOPJ) testWhenGroupIsInIrregularCase(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, agencies, returnedAgencies)
+	truncateTables()
+}
+
+func TestGetAgenciesByUF(t *testing.T) {
+	tests := getAgenciesByUF{}
+	t.Run("Test GetAgenciesByUF when agencies exists", tests.testWhenAgenciesExists)
+	t.Run("Test GetAgenciesByUF when UF not exists", tests.testWhenUFNotExists)
+	t.Run("Test GetAgenciesByUF when UF is in irregular case", tests.testWhenUFIsInIrregularCase)
+}
+
+type getAgenciesByUF struct{}
+
+func (g getAgenciesByUF) testWhenAgenciesExists(t *testing.T) {
+	agencies := []models.Agency{
+		{
+			ID:   "mpsp",
+			Type: "Ministério",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjsp",
+			Type: "Estadual",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjmsp",
+			Type: "Militar",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjal",
+			Type: "Estadual",
+			UF:   "AL",
+		},
+	}
+	if err := insertAgencies(agencies); err != nil {
+		t.Fatalf("error inserting agencies: %q", err)
+	}
+
+	returnedAgencies, err := postgresDb.GetAgenciesByUF("SP")
+
+	assert.Nil(t, err)
+	assert.Equal(t, agencies[:3], returnedAgencies)
+	truncateTables()
+}
+
+func (g getAgenciesByUF) testWhenUFNotExists(t *testing.T) {
+	truncateTables()
+
+	returnedAgencies, err := postgresDb.GetAgenciesByUF("SP")
+
+	assert.Nil(t, err)
+	assert.Empty(t, returnedAgencies)
+}
+
+func (g getAgenciesByUF) testWhenUFIsInIrregularCase(t *testing.T) {
+	agencies := []models.Agency{
+		{
+			ID:   "mpsp",
+			Type: "Ministério",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjsp",
+			Type: "Estadual",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjmsp",
+			Type: "Militar",
+			UF:   "SP",
+		},
+		{
+			ID:   "tjal",
+			Type: "Estadual",
+			UF:   "AL",
+		},
+	}
+	if err := insertAgencies(agencies); err != nil {
+		t.Fatalf("error inserting agencies: %q", err)
+	}
+
+	returnedAgencies, err := postgresDb.GetAgenciesByUF("sP")
+
+	assert.Nil(t, err)
+	assert.Equal(t, agencies[:3], returnedAgencies)
 	truncateTables()
 }
 


### PR DESCRIPTION
Essa pr, além de criar os testes do método que busca os órgãos pela UF, diferencia os métodos getOPE e getAgencies. Antes eles faziam tecnicamente a mesma coisa(pegar os órgãos pela UF), até que foi adicionada uma restrição no getOPE que pegava apenas os órgãos estaduais. Por isso, resolvi modificar o nome dos métodos para deixar um pouco mais claro o que eles fazem.