### PR TITLE
Pegando os dados do datapackage anual

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,3 +105,19 @@ func (c *Client) GetFirstDateWithMonthlyInfo() (int, int, error) {
 	}
 	return month, year, nil
 }
+
+func (c *Client) GetAnnualSummary(agency string) ([]models.AnnualSummary, error) {
+	summary, err := c.Db.GetAnnualSummary(agency)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting annual data from database: %q", err)
+	}
+	for i := range summary {
+		dstKey := fmt.Sprintf("%s/datapackage/%s-%d.zip", agency, agency, summary[i].Year)
+		pkg, err := c.Cloud.GetFile(dstKey)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting annual data from file storage: %q", err)
+		}
+		summary[i].Package = pkg
+	}
+	return summary, nil
+}

--- a/models/monthlyInfo.go
+++ b/models/monthlyInfo.go
@@ -76,10 +76,11 @@ type GeneralMonthlyInfo struct {
 }
 
 type AnnualSummary struct {
-	Year               int     `json:"year,omitempty"`      // Year of the data
-	Count              int     `json:"count"`               // Number of employees
-	BaseRemuneration   float64 `json:"base_remuneration"`   //  Statistics (Max, Min, Median, Total)
-	OtherRemunerations float64 `json:"other_remunerations"` //  Statistics (Max, Min, Median, Total)
+	Year               int     `json:"year,omitempty"`                // Year of the data
+	Count              int     `json:"count,omitempty"`               // Number of employees
+	BaseRemuneration   float64 `json:"base_remuneration,omitempty"`   //  Statistics (Max, Min, Median, Total)
+	OtherRemunerations float64 `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
+	Package            *Backup `json:"package,omitempty"`
 }
 
 type RemmunerationSummary struct {


### PR DESCRIPTION
Jessé me pediu alguns dados a mais que seriam necessários para a página ano-a-ano, como o datapackage anual que vem do S3. Resolvi centralizar a coleta dos dados no client do storage.