### PR TITLE
Retornando resumo_rubricas para api

### DIFF
--- a/models/monthlyInfo.go
+++ b/models/monthlyInfo.go
@@ -75,7 +75,7 @@ type GeneralMonthlyInfo struct {
 	OtherRemunerations float64     `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
 	Discounts          float64     `json:"discounts,omitempty"`           //  Statistics (Max, Min, Median, Total)
 	Remunerations      float64     `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
-	ItemSummary        ItemSummary `json:"resumo_rubricas,omitempty"`
+	ItemSummary        ItemSummary `json:"item_summary,omitempty"`
 }
 
 type AnnualSummary struct {
@@ -88,7 +88,7 @@ type AnnualSummary struct {
 	Remunerations      float64     `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
 	NumMonthsWithData  int         `json:"months_with_data,omitempty"`
 	Package            *Backup     `json:"package,omitempty"`
-	ItemSummary        ItemSummary `json:"resumo_rubricas,omitempty"`
+	ItemSummary        ItemSummary `json:"item_summary,omitempty"`
 }
 
 type RemmunerationSummary struct {

--- a/models/monthlyInfo.go
+++ b/models/monthlyInfo.go
@@ -69,24 +69,26 @@ type MonthlyInfoVersion struct {
 
 // the GeneralMonthlyInfo is used to struct the agregation used to get the remuneration info from all angencies in a given month
 type GeneralMonthlyInfo struct {
-	Month              int     `json:"_id,omitempty"`
-	Count              int     `json:"count,omitempty"`               // Number of employees
-	BaseRemuneration   float64 `json:"base_remuneration,omitempty"`   //  Statistics (Max, Min, Median, Total)
-	OtherRemunerations float64 `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
-	Discounts          float64 `json:"discounts,omitempty"`           //  Statistics (Max, Min, Median, Total)
-	Remunerations      float64 `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
+	Month              int         `json:"_id,omitempty"`
+	Count              int         `json:"count,omitempty"`               // Number of employees
+	BaseRemuneration   float64     `json:"base_remuneration,omitempty"`   //  Statistics (Max, Min, Median, Total)
+	OtherRemunerations float64     `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
+	Discounts          float64     `json:"discounts,omitempty"`           //  Statistics (Max, Min, Median, Total)
+	Remunerations      float64     `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
+	ItemSummary        ItemSummary `json:"resumo_rubricas,omitempty"`
 }
 
 type AnnualSummary struct {
-	Year               int     `json:"year,omitempty"`                // Year of the data
-	AverageCount       int     `json:"average_count,omitempty"`       // Average number of employees
-	TotalCount         int     `json:"total_count,omitempty"`         // Total number of employees
-	BaseRemuneration   float64 `json:"base_remuneration,omitempty"`   //  Statistics (Max, Min, Median, Total)
-	OtherRemunerations float64 `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
-	Discounts          float64 `json:"discounts,omitempty"`           //  Statistics (Max, Min, Median, Total)
-	Remunerations      float64 `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
-	NumMonthsWithData  int     `json:"months_with_data,omitempty"`
-	Package            *Backup `json:"package,omitempty"`
+	Year               int         `json:"year,omitempty"`                // Year of the data
+	AverageCount       int         `json:"average_count,omitempty"`       // Average number of employees
+	TotalCount         int         `json:"total_count,omitempty"`         // Total number of employees
+	BaseRemuneration   float64     `json:"base_remuneration,omitempty"`   //  Statistics (Max, Min, Median, Total)
+	OtherRemunerations float64     `json:"other_remunerations,omitempty"` //  Statistics (Max, Min, Median, Total)
+	Discounts          float64     `json:"discounts,omitempty"`           //  Statistics (Max, Min, Median, Total)
+	Remunerations      float64     `json:"remunerations,omitempty"`       //  Statistics (Max, Min, Median, Total)
+	NumMonthsWithData  int         `json:"months_with_data,omitempty"`
+	Package            *Backup     `json:"package,omitempty"`
+	ItemSummary        ItemSummary `json:"resumo_rubricas,omitempty"`
 }
 
 type RemmunerationSummary struct {

--- a/repo/database/dto/annuaISummary.go
+++ b/repo/database/dto/annuaISummary.go
@@ -13,6 +13,7 @@ type AnnualSummaryDTO struct {
 	Discounts          float64 `gorm:"column:descontos"`
 	Remunerations      float64 `gorm:"column:remuneracoes"`
 	NumMonthsWithData  int     `gorm:"column:meses_com_dados"`
+	ItemSummary
 }
 
 func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {
@@ -25,6 +26,10 @@ func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {
 		Discounts:          ami.Discounts,
 		Remunerations:      ami.Remunerations,
 		NumMonthsWithData:  ami.NumMonthsWithData,
+		ItemSummary: ItemSummary{
+			FoodAllowance: ami.ItemSummary.FoodAllowance,
+			Others:        ami.ItemSummary.Others,
+		},
 	}
 }
 
@@ -38,5 +43,9 @@ func (ami *AnnualSummaryDTO) ConvertToModel() *models.AnnualSummary {
 		Discounts:          ami.Discounts,
 		Remunerations:      ami.Remunerations,
 		NumMonthsWithData:  ami.NumMonthsWithData,
+		ItemSummary: models.ItemSummary{
+			FoodAllowance: ami.ItemSummary.FoodAllowance,
+			Others:        ami.ItemSummary.Others,
+		},
 	}
 }

--- a/repo/database/dto/annuaISummary.go
+++ b/repo/database/dto/annuaISummary.go
@@ -5,15 +5,15 @@ import (
 )
 
 type AnnualSummaryDTO struct {
-	Year               int     `gorm:"column:ano"`
-	AverageCount       int     `gorm:"column:media_num_membros"`
-	TotalCount         int     `gorm:"column:total_num_membros"`
-	BaseRemuneration   float64 `gorm:"column:remuneracao_base"`
-	OtherRemunerations float64 `gorm:"column:outras_remuneracoes"`
-	Discounts          float64 `gorm:"column:descontos"`
-	Remunerations      float64 `gorm:"column:remuneracoes"`
-	NumMonthsWithData  int     `gorm:"column:meses_com_dados"`
-	ItemSummary
+	Year               int         `gorm:"column:ano"`
+	AverageCount       int         `gorm:"column:media_num_membros"`
+	TotalCount         int         `gorm:"column:total_num_membros"`
+	BaseRemuneration   float64     `gorm:"column:remuneracao_base"`
+	OtherRemunerations float64     `gorm:"column:outras_remuneracoes"`
+	Discounts          float64     `gorm:"column:descontos"`
+	Remunerations      float64     `gorm:"column:remuneracoes"`
+	NumMonthsWithData  int         `gorm:"column:meses_com_dados"`
+	ItemSummary        ItemSummary `gorm:"embedded"`
 }
 
 func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {

--- a/repo/database/dto/generalMonthlyInfo.go
+++ b/repo/database/dto/generalMonthlyInfo.go
@@ -11,6 +11,12 @@ type GeneralMonthlyInfoDTO struct {
 	OtherRemunerations float64 `gorm:"column:outras_remuneracoes"`
 	Discounts          float64 `gorm:"column:descontos"`
 	Remunerations      float64 `gorm:"column:remuneracoes"`
+	ItemSummary
+}
+
+type ItemSummary struct {
+	FoodAllowance float64 `gorm:"column:auxilio_alimentacao"`
+	Others        float64 `gorm:"column:outras"`
 }
 
 func NewGeneralMonthlyInfoDTO(gmi models.GeneralMonthlyInfo) *GeneralMonthlyInfoDTO {
@@ -21,6 +27,10 @@ func NewGeneralMonthlyInfoDTO(gmi models.GeneralMonthlyInfo) *GeneralMonthlyInfo
 		OtherRemunerations: gmi.OtherRemunerations,
 		Discounts:          gmi.Discounts,
 		Remunerations:      gmi.Remunerations,
+		ItemSummary: ItemSummary{
+			FoodAllowance: gmi.ItemSummary.FoodAllowance,
+			Others:        gmi.ItemSummary.Others,
+		},
 	}
 }
 
@@ -32,5 +42,9 @@ func (gmi *GeneralMonthlyInfoDTO) ConvertToModel() *models.GeneralMonthlyInfo {
 		OtherRemunerations: gmi.OtherRemunerations,
 		Discounts:          gmi.Discounts,
 		Remunerations:      gmi.Remunerations,
+		ItemSummary: models.ItemSummary{
+			FoodAllowance: gmi.ItemSummary.FoodAllowance,
+			Others:        gmi.ItemSummary.Others,
+		},
 	}
 }

--- a/repo/database/dto/generalMonthlyInfo.go
+++ b/repo/database/dto/generalMonthlyInfo.go
@@ -5,13 +5,13 @@ import (
 )
 
 type GeneralMonthlyInfoDTO struct {
-	Month              int     `gorm:"column:mes"`
-	Count              int     `gorm:"column:num_membros"`
-	BaseRemuneration   float64 `gorm:"column:remuneracao_base"`
-	OtherRemunerations float64 `gorm:"column:outras_remuneracoes"`
-	Discounts          float64 `gorm:"column:descontos"`
-	Remunerations      float64 `gorm:"column:remuneracoes"`
-	ItemSummary
+	Month              int         `gorm:"column:mes"`
+	Count              int         `gorm:"column:num_membros"`
+	BaseRemuneration   float64     `gorm:"column:remuneracao_base"`
+	OtherRemunerations float64     `gorm:"column:outras_remuneracoes"`
+	Discounts          float64     `gorm:"column:descontos"`
+	Remunerations      float64     `gorm:"column:remuneracoes"`
+	ItemSummary        ItemSummary `gorm:"embedded"`
 }
 
 type ItemSummary struct {

--- a/repo/database/postgres.go
+++ b/repo/database/postgres.go
@@ -315,6 +315,8 @@ func (p *PostgresDB) GetAnnualSummary(agency string) ([]models.AnnualSummary, er
 		SUM(CAST(sumario -> 'outras_remuneracoes' ->> 'total' AS DECIMAL)) AS outras_remuneracoes,
 		SUM(CAST(sumario -> 'descontos' ->> 'total' AS DECIMAL)) AS descontos,
 		SUM(CAST(sumario -> 'remuneracoes' ->> 'total' AS DECIMAL)) AS remuneracoes,
+		SUM(CAST(sumario -> 'resumo_rubricas' ->> 'auxilio_alimentacao' AS DECIMAL)) AS auxilio_alimentacao,
+		SUM(CAST(sumario -> 'resumo_rubricas' ->> 'outras' AS DECIMAL)) AS outras,
 		COUNT(*) AS meses_com_dados`
 	m := p.db.Model(&dtoAgmi).Select(query)
 	m = m.Where("id_orgao = ? AND atual = TRUE AND (procinfo::text = 'null' OR procinfo IS NULL) ", agency)
@@ -359,7 +361,9 @@ func (p *PostgresDB) GetGeneralMonthlyInfosFromYear(year int) ([]models.GeneralM
 		SUM(CAST(sumario -> 'remuneracao_base' ->> 'total' AS DECIMAL)) AS remuneracao_base,
 		SUM(CAST(sumario -> 'outras_remuneracoes' ->> 'total' AS DECIMAL)) AS outras_remuneracoes,
 		SUM(CAST(sumario -> 'descontos' ->> 'total' AS DECIMAL)) AS descontos,
-		SUM(CAST(sumario -> 'remuneracoes' ->> 'total' AS DECIMAL)) AS remuneracoes`
+		SUM(CAST(sumario -> 'remuneracoes' ->> 'total' AS DECIMAL)) AS remuneracoes,
+		SUM(CAST(sumario -> 'resumo_rubricas' ->> 'auxilio_alimentacao' AS DECIMAL)) AS auxilio_alimentacao,
+		SUM(CAST(sumario -> 'resumo_rubricas' ->> 'outras' AS DECIMAL)) AS outras`
 	m := p.db.Model(&dtoAgmi).Select(query)
 	m = m.Where("ano = ? AND atual=true AND (procinfo IS NULL OR procinfo::text = 'null')", year)
 	m = m.Group("mes").Order("mes ASC")

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -945,6 +945,9 @@ func (g getAnnualSummary) testWhenMonthlyInfoExists(t *testing.T) {
 				Remunerations: models.DataSummary{
 					Total: 1000,
 				},
+				ItemSummary: models.ItemSummary{
+					Others: 100,
+				},
 			},
 		},
 		{
@@ -1035,6 +1038,9 @@ func (g getAnnualSummary) testWhenMonthlyInfoExists(t *testing.T) {
 						OtherRemunerations: agmi.Summary.OtherRemunerations.Total + agmi2.Summary.OtherRemunerations.Total,
 						Discounts:          agmi.Summary.Discounts.Total + agmi2.Summary.Discounts.Total,
 						Remunerations:      agmi.Summary.Remunerations.Total + agmi2.Summary.Remunerations.Total,
+						ItemSummary: models.ItemSummary{
+							Others: agmi.Summary.ItemSummary.Others + agmi2.Summary.ItemSummary.Others,
+						},
 					})
 				}
 			}
@@ -1054,6 +1060,7 @@ func (g getAnnualSummary) testWhenMonthlyInfoExists(t *testing.T) {
 	assert.Equal(t, amis[0].TotalCount, returnedAmis[0].TotalCount)
 	assert.Equal(t, amis[1].TotalCount, returnedAmis[1].TotalCount)
 	assert.Equal(t, 2, returnedAmis[0].NumMonthsWithData)
+	assert.Equal(t, amis[0].ItemSummary.Others, returnedAmis[0].ItemSummary.Others)
 	truncateTables()
 }
 
@@ -1184,6 +1191,9 @@ func (g getGeneralMonthlyInfoFromYear) testWhenDataExists(t *testing.T) {
 				Remunerations: models.DataSummary{
 					Total: 1000,
 				},
+				ItemSummary: models.ItemSummary{
+					FoodAllowance: 200,
+				},
 			},
 		},
 		{
@@ -1235,6 +1245,9 @@ func (g getGeneralMonthlyInfoFromYear) testWhenDataExists(t *testing.T) {
 						OtherRemunerations: agmi.Summary.OtherRemunerations.Total + agmi2.Summary.OtherRemunerations.Total,
 						Discounts:          agmi.Summary.Discounts.Total + agmi2.Summary.Discounts.Total,
 						Remunerations:      agmi.Summary.Remunerations.Total + agmi2.Summary.Remunerations.Total,
+						ItemSummary: models.ItemSummary{
+							FoodAllowance: agmi.Summary.ItemSummary.FoodAllowance + agmi2.Summary.ItemSummary.FoodAllowance,
+						},
 					})
 				}
 			}
@@ -1383,6 +1396,10 @@ func (s store) testWhenDataIsOK(t *testing.T) {
 				Total:   63744055.95,
 			},
 			IncomeHistogram: map[int]int{-1: 0, 10000: 0, 20000: 0, 30000: 116, 40000: 546, 50000: 0},
+			ItemSummary: models.ItemSummary{
+				FoodAllowance: 100,
+				Others:        200,
+			},
 		},
 		CrawlerVersion:    "b9ec52df612cda045544543a3b0387842475764d",
 		CrawlerRepo:       "https://github.com/dadosjusbr/coletor-cnj",
@@ -1444,6 +1461,7 @@ func (s store) testWhenDataIsOK(t *testing.T) {
 	assert.Equal(t, agmi.Meta.Extension, result.Meta.Extension)
 	assert.Equal(t, agmi.Score.Score, result.Score.Score)
 	assert.Equal(t, agmi.Duration, result.Duration)
+	assert.Equal(t, agmi.Summary.ItemSummary.FoodAllowance, result.Summary.ItemSummary.FoodAllowance)
 	truncateTables()
 }
 


### PR DESCRIPTION
- Algumas rotas precisam de modificação no storage para retornar esses campos (ex.: a rota que faz o gráfico da página principal)
- Adicionando o campo aos testes