### PR TITLE
Inconsistent column

### DIFF
--- a/models/monthlyInfo.go
+++ b/models/monthlyInfo.go
@@ -37,6 +37,7 @@ type AgencyMonthlyInfo struct {
 	Score             *Score                 `json:"score,omitempty"`
 	Duration          float64                `json:"duration,omitempty"`      // Crawling duration (seconds)
 	ManualCollection  bool                   `json:"coleta_manual,omitempty"` // If the data was collected manually
+	Inconsistent      bool                   `json:"inconsistent"`            // If the data is inconsistent
 }
 
 type Meta struct {
@@ -94,6 +95,7 @@ type AnnualSummary struct {
 	NumMonthsWithData           int         `json:"months_with_data,omitempty"`
 	Package                     *Backup     `json:"package,omitempty"`
 	ItemSummary                 ItemSummary `json:"item_summary,omitempty"`
+	Inconsistent                bool        `json:"inconsistent,omitempty"` // If the data is inconsistent
 }
 
 type RemmunerationSummary struct {

--- a/repo/database/dto/annuaISummary.go
+++ b/repo/database/dto/annuaISummary.go
@@ -18,6 +18,7 @@ type AnnualSummaryDTO struct {
 	RemunerationsPerCapita      float64     `gorm:"column:remuneracoes_membro"`
 	NumMonthsWithData           int         `gorm:"column:meses_com_dados"`
 	ItemSummary                 ItemSummary `gorm:"embedded"`
+	Inconsistent                bool        `gorm:"column:inconsistente"`
 }
 
 func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {
@@ -44,6 +45,7 @@ func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {
 			HealthAllowance:      ami.ItemSummary.HealthAllowance,
 			Others:               ami.ItemSummary.Others,
 		},
+		Inconsistent: ami.Inconsistent,
 	}
 }
 
@@ -71,5 +73,6 @@ func (ami *AnnualSummaryDTO) ConvertToModel() *models.AnnualSummary {
 			HealthAllowance:      ami.ItemSummary.HealthAllowance,
 			Others:               ami.ItemSummary.Others,
 		},
+		Inconsistent: ami.Inconsistent,
 	}
 }

--- a/repo/database/dto/annuaISummary.go
+++ b/repo/database/dto/annuaISummary.go
@@ -18,7 +18,7 @@ type AnnualSummaryDTO struct {
 	RemunerationsPerCapita      float64     `gorm:"column:remuneracoes_membro"`
 	NumMonthsWithData           int         `gorm:"column:meses_com_dados"`
 	ItemSummary                 ItemSummary `gorm:"embedded"`
-	Inconsistent                bool        `gorm:"column:inconsistente"`
+	Inconsistent                bool        `gorm:"column:inconsistente;<-:false"`
 }
 
 func NewAnnualSummaryDTO(ami models.AnnualSummary) *AnnualSummaryDTO {

--- a/repo/database/dto/monthlyInfoDTO.go
+++ b/repo/database/dto/monthlyInfoDTO.go
@@ -32,6 +32,7 @@ type AgencyMonthlyInfoDTO struct {
 	Meta
 	Score
 	ManualCollection bool `gorm:"column:manual"` // Tempo de execução da coleta em segundos
+	Inconsistent     bool `gorm:"column:inconsistente"`
 }
 
 func (AgencyMonthlyInfoDTO) TableName() string {
@@ -133,6 +134,7 @@ func (a AgencyMonthlyInfoDTO) ConvertToModel() (*models.AgencyMonthlyInfo, error
 		Package:          &pkg,
 		Duration:         a.Duration,
 		ManualCollection: a.ManualCollection,
+		Inconsistent:     a.Inconsistent,
 	}, nil
 }
 
@@ -212,6 +214,7 @@ func NewAgencyMonthlyInfoDTO(agmi models.AgencyMonthlyInfo) (*AgencyMonthlyInfoD
 		Package:          pkg,
 		Duration:         agmi.Duration,
 		ManualCollection: agmi.ManualCollection,
+		Inconsistent:     agmi.Inconsistent,
 	}, nil
 }
 

--- a/repo/database/dto/monthlyInfoDTO.go
+++ b/repo/database/dto/monthlyInfoDTO.go
@@ -31,8 +31,8 @@ type AgencyMonthlyInfoDTO struct {
 	Duration       float64        `gorm:"column:duracao_segundos"` // Tempo de execução da coleta em segundos
 	Meta
 	Score
-	ManualCollection bool `gorm:"column:manual"` // Tempo de execução da coleta em segundos
-	Inconsistent     bool `gorm:"column:inconsistente"`
+	ManualCollection bool `gorm:"column:manual"` // A coleta foi realizada manualmente?
+	Inconsistent     bool `gorm:"column:inconsistente;<-:false"`
 }
 
 func (AgencyMonthlyInfoDTO) TableName() string {

--- a/repo/database/postgres.go
+++ b/repo/database/postgres.go
@@ -326,7 +326,6 @@ func (p *PostgresDB) GetMonthlyInfo(agencies []models.Agency, year int) (map[str
 }
 
 func (p *PostgresDB) GetAnnualSummary(agency string) ([]models.AnnualSummary, error) {
-	// var dtoAgmi dto.AgencyMonthlyInfoDTO
 	var dtoAmis []dto.AnnualSummaryDTO
 	agency = strings.ToLower(agency)
 

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -1142,6 +1142,8 @@ func (g getAnnualSummary) testWhenMonthlyInfoExists(t *testing.T) {
 	assert.Equal(t, amis[1].ItemSummary.Vacation, returnedAmis[1].ItemSummary.Vacation)
 	assert.Equal(t, 1000.0, returnedAmis[2].BaseRemunerationPerCapita)
 	assert.Equal(t, 1200.0, returnedAmis[2].OtherRemunerationsPerCapita)
+	assert.Equal(t, amis[0].Inconsistent, returnedAmis[0].Inconsistent)
+	assert.Equal(t, false, returnedAmis[0].Inconsistent)
 	truncateTables()
 }
 

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -788,6 +788,7 @@ func (g getMonthlyInfo) testWhenMonthlyInfoExists(t *testing.T) {
 			Month:             1,
 			CrawlingTimestamp: timestamppb.Now(),
 			ManualCollection:  false,
+			Inconsistent:      false,
 		},
 		{
 			AgencyID:          "tjsp",
@@ -795,6 +796,7 @@ func (g getMonthlyInfo) testWhenMonthlyInfoExists(t *testing.T) {
 			Month:             1,
 			CrawlingTimestamp: timestamppb.Now(),
 			ManualCollection:  true,
+			Inconsistent:      false,
 		},
 	}
 	if err := insertMonthlyInfos(agmis); err != nil {
@@ -1191,6 +1193,7 @@ func (g getOMA) testWhenDataExists(t *testing.T) {
 	assert.Equal(t, agmi.Month, returnedAgmi.Month)
 	assert.Equal(t, agmi.Year, returnedAgmi.Year)
 	assert.Equal(t, agencies[0], *agency)
+	assert.Equal(t, returnedAgmi.Inconsistent, false)
 	truncateTables()
 }
 


### PR DESCRIPTION
- Retorna a coluna inconsistente da tabela de remunerações, informação agregada por mês e ano.
- Otimizando as queries
  - Devido a junção com a tabela de remunerações, algumas consultas estavam demorando demais.
  - Conseguimos otimizar as consultas de mais de 1min para 19s (isso localmente)
  - Não se assustem com o tamanho da query da função GetAnnualSummary, ela tava levando 2m20 antes da modificação :pray: 