### PR TITLE
retorna a média por membro

### DIFF
--- a/repo/database/database_mock.go
+++ b/repo/database/database_mock.go
@@ -152,6 +152,21 @@ func (mr *MockInterfaceMockRecorder) GetAnnualSummary(agency interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnualSummary", reflect.TypeOf((*MockInterface)(nil).GetAnnualSummary), agency)
 }
 
+// GetAveragePerAgency mocks base method.
+func (m *MockInterface) GetAveragePerAgency(year int) ([]models.PerCapitaData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAveragePerAgency", year)
+	ret0, _ := ret[0].([]models.PerCapitaData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAveragePerAgency indicates an expected call of GetAveragePerAgency.
+func (mr *MockInterfaceMockRecorder) GetAveragePerAgency(year interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAveragePerAgency", reflect.TypeOf((*MockInterface)(nil).GetAveragePerAgency), year)
+}
+
 // GetAveragePerCapita mocks base method.
 func (m *MockInterface) GetAveragePerCapita(agency string, year int) (*models.PerCapitaData, error) {
 	m.ctrl.T.Helper()
@@ -348,21 +363,6 @@ func (m *MockInterface) GetPaychecks(agency models.Agency, year int) ([]models.P
 func (mr *MockInterfaceMockRecorder) GetPaychecks(agency, year interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaychecks", reflect.TypeOf((*MockInterface)(nil).GetPaychecks), agency, year)
-}
-
-// GetPerCapitaData mocks base method.
-func (m *MockInterface) GetPerCapitaData(year int) ([]models.PerCapitaData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPerCapitaData", year)
-	ret0, _ := ret[0].([]models.PerCapitaData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPerCapitaData indicates an expected call of GetPerCapitaData.
-func (mr *MockInterfaceMockRecorder) GetPerCapitaData(year interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPerCapitaData", reflect.TypeOf((*MockInterface)(nil).GetPerCapitaData), year)
 }
 
 // GetStateAgencies mocks base method.

--- a/repo/database/database_mock.go
+++ b/repo/database/database_mock.go
@@ -350,6 +350,21 @@ func (mr *MockInterfaceMockRecorder) GetPaychecks(agency, year interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaychecks", reflect.TypeOf((*MockInterface)(nil).GetPaychecks), agency, year)
 }
 
+// GetPerCapitaData mocks base method.
+func (m *MockInterface) GetPerCapitaData(year int) ([]models.PerCapitaData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPerCapitaData", year)
+	ret0, _ := ret[0].([]models.PerCapitaData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPerCapitaData indicates an expected call of GetPerCapitaData.
+func (mr *MockInterfaceMockRecorder) GetPerCapitaData(year interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPerCapitaData", reflect.TypeOf((*MockInterface)(nil).GetPerCapitaData), year)
+}
+
 // GetStateAgencies mocks base method.
 func (m *MockInterface) GetStateAgencies(uf string) ([]models.Agency, error) {
 	m.ctrl.T.Helper()

--- a/repo/database/interface.go
+++ b/repo/database/interface.go
@@ -34,5 +34,5 @@ type Interface interface {
 	GetPaycheckItems(agency models.Agency, year int) ([]models.PaycheckItem, error)
 	GetAveragePerCapita(agency string, year int) (*models.PerCapitaData, error)
 	GetNotices(agency string, year int, month int) ([]*string, error)
-	GetPerCapitaData(year int) ([]models.PerCapitaData, error)
+	GetAveragePerAgency(year int) ([]models.PerCapitaData, error)
 }

--- a/repo/database/interface.go
+++ b/repo/database/interface.go
@@ -34,4 +34,5 @@ type Interface interface {
 	GetPaycheckItems(agency models.Agency, year int) ([]models.PaycheckItem, error)
 	GetAveragePerCapita(agency string, year int) (*models.PerCapitaData, error)
 	GetNotices(agency string, year int, month int) ([]*string, error)
+	GetPerCapitaData(year int) ([]models.PerCapitaData, error)
 }

--- a/repo/database/postgres.go
+++ b/repo/database/postgres.go
@@ -825,9 +825,9 @@ func (p *PostgresDB) GetNotices(agency string, year int, month int) ([]*string, 
 	return notices, nil
 }
 
-// GetPerCapitaData retorna os dados per capita para um determinado ano de cada órgão.
+// GetAveragePerAgency( retorna os dados per capita para um determinado ano de cada órgão.
 // Isto é, salário, benefícios, descontos e remuneração médio por membro em um ano.
-func (p *PostgresDB) GetPerCapitaData(year int) ([]models.PerCapitaData, error) {
+func (p *PostgresDB) GetAveragePerAgency(year int) ([]models.PerCapitaData, error) {
 	var dtoPerCapitaData []dto.PerCapitaData
 	m := p.db.Model(&dto.PerCapitaData{})
 	m = m.Where("ano = ?", year)
@@ -835,10 +835,10 @@ func (p *PostgresDB) GetPerCapitaData(year int) ([]models.PerCapitaData, error) 
 		return nil, fmt.Errorf("error getting per capita data: %q", err)
 	}
 
-	var perCapitaData []models.PerCapitaData
+	var averagePerAgency []models.PerCapitaData
 	for _, dtoData := range dtoPerCapitaData {
 		data := dtoData.ConvertToModel()
-		perCapitaData = append(perCapitaData, *data)
+		averagePerAgency = append(averagePerAgency, *data)
 	}
-	return perCapitaData, nil
+	return averagePerAgency, nil
 }

--- a/repo/database/postgres.go
+++ b/repo/database/postgres.go
@@ -824,3 +824,21 @@ func (p *PostgresDB) GetNotices(agency string, year int, month int) ([]*string, 
 
 	return notices, nil
 }
+
+// GetPerCapitaData retorna os dados per capita para um determinado ano de cada órgão.
+// Isto é, salário, benefícios, descontos e remuneração médio por membro em um ano.
+func (p *PostgresDB) GetPerCapitaData(year int) ([]models.PerCapitaData, error) {
+	var dtoPerCapitaData []dto.PerCapitaData
+	m := p.db.Model(&dto.PerCapitaData{})
+	m = m.Where("ano = ?", year)
+	if err := m.Find(&dtoPerCapitaData).Error; err != nil {
+		return nil, fmt.Errorf("error getting per capita data: %q", err)
+	}
+
+	var perCapitaData []models.PerCapitaData
+	for _, dtoData := range dtoPerCapitaData {
+		data := dtoData.ConvertToModel()
+		perCapitaData = append(perCapitaData, *data)
+	}
+	return perCapitaData, nil
+}

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -2298,16 +2298,16 @@ func (averagePerCapita) testGetAveragePerCapita(t *testing.T) {
 	assert.Equal(t, 2000.0, avg.Remunerations)
 }
 
-type perCapitaData struct{}
+type averagePerAgency struct{}
 
-func TestPerCapitaData(t *testing.T) {
-	tests := perCapitaData{}
+func TestAveragePerAgency(t *testing.T) {
+	tests := averagePerAgency{}
 
-	t.Run("Test GetPerCapitaData()", tests.TestGetPerCapitaData)
+	t.Run("Test GetaveragePerAgency()", tests.TestGetAveragePerAgency)
 }
 
-func (perCapitaData) TestGetPerCapitaData(t *testing.T) {
-	apcd, err := postgresDb.GetPerCapitaData(2023)
+func (averagePerAgency) TestGetAveragePerAgency(t *testing.T) {
+	apcd, err := postgresDb.GetAveragePerAgency(2023)
 	if err != nil {
 		t.Fatalf("error GetAveragePerCapita(): %v", err)
 	}

--- a/repo/database/postgres_test.go
+++ b/repo/database/postgres_test.go
@@ -2298,6 +2298,30 @@ func (averagePerCapita) testGetAveragePerCapita(t *testing.T) {
 	assert.Equal(t, 2000.0, avg.Remunerations)
 }
 
+type perCapitaData struct{}
+
+func TestPerCapitaData(t *testing.T) {
+	tests := perCapitaData{}
+
+	t.Run("Test GetPerCapitaData()", tests.TestGetPerCapitaData)
+}
+
+func (perCapitaData) TestGetPerCapitaData(t *testing.T) {
+	apcd, err := postgresDb.GetPerCapitaData(2023)
+	if err != nil {
+		t.Fatalf("error GetAveragePerCapita(): %v", err)
+	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, "tjal", apcd[0].AgencyID)
+	assert.Equal(t, 2023, apcd[0].Year)
+	assert.Equal(t, 1000.0, apcd[0].BaseRemuneration)
+	assert.Equal(t, 1200.0, apcd[0].OtherRemunerations)
+	assert.Equal(t, 200.0, apcd[0].Discounts)
+	assert.Equal(t, 2000.0, apcd[0].Remunerations)
+	assert.Equal(t, 1, len(apcd))
+}
+
 func insertAgencies(agencies []models.Agency) error {
 	for _, agency := range agencies {
 		agencyDto, err := dto.NewAgencyDTO(agency)


### PR DESCRIPTION
- retorna as médias por membro de cada categoria em um ano para cada órgão

```json
[
   {
      "id_orgao": "cjf",
      "media_por_membro": {
         "remuneracao_base": 4024.1091666666666,
         "outras_remuneracoes": 502.5152777777778,
         "descontos": 1369.9430555555555,
         "remuneracoes": 3156.6813888888887
      }
   },
   ...
]
```